### PR TITLE
Move imports of matplotlib and dmdd_plot into the functions where they are used

### DIFF
--- a/dmdd/dmdd.py
+++ b/dmdd/dmdd.py
@@ -3,7 +3,6 @@ try:
     import rate_genNR  
     import rate_UV 
     import dmdd_efficiencies as eff
-    import dmdd_plot as dp
 except ImportError:
     pass
     
@@ -16,7 +15,6 @@ on_rtd = False
 
 try:
     import numpy.random as random
-    import matplotlib.pyplot as plt
     import numpy as np
     from scipy.stats import poisson
     from scipy.interpolate import UnivariateSpline as interpolate
@@ -455,6 +453,7 @@ class MultinestRun(object):
         """
 
         #make theory, data, and fit plots for each experiment:
+        import dmdd_plot as dp
         fitmodel_dRdQ_params = self.fit_model.default_rate_parameters
         param_values = self.global_bestfit()
         if len(self.fit_model.fixed_params) > 0:
@@ -768,6 +767,7 @@ class Simulation(object):
         Qbins_theory = self.model_Qgrid
 
         if make_plot:
+            import matplotlib.pyplot as plt
             plt.figure()
             plt.title('%s (total events = %i)' % (self.experiment.name,self.N), fontsize=18)
             xlabel = 'Nuclear recoil energy [keV]'
@@ -1072,6 +1072,7 @@ class Experiment(object):
                                             v_esc=v_esc, v_lag=v_lag, v_rms=v_rms, rho_x=rho_x)
 
         if make_plot:
+            import matplotlib.pyplot as plt
             plt.figure()
             plt.loglog(masses, sigmas * PAR_NORMS[sigma_name], lw=3, color='k')
             plt.xlabel(PARAM_TEX['mass'])

--- a/dmdd/tests/test.py
+++ b/dmdd/tests/test.py
@@ -1,7 +1,6 @@
 import os,os.path,shutil
 import numpy as np
 import pickle
-import matplotlib.pyplot as plt
 
 import dmdd
 import dmdd_efficiencies as eff


### PR DESCRIPTION
Hi

This pull request moves imports of matplotlib and dmdd_plot inside the functions where they are used, so that they are not imported unless they need to be.

A user (Renee Hlozek)  is trying to use dmdd in connection with my project's code (cosmosis), and seeing a problem on OSX with an "abort trap 6" error when matplotlib is loaded.  We've seen this before - it's is a horribly painful problem that can happen whenever the c++ code in matplotlib interacts with the compilers used to build other code.

This PR stops that problem from showing up by removing the matplotlib imports from the top level, so that the code can be imported and the non-visualization routines run without crashing.  It shouldn't affect any functionality.

Thanks!
Joe Zuntz
